### PR TITLE
feat(ci): align release build with ai-coder & define branch rules

### DIFF
--- a/.github/workflows/ai-coder.yml
+++ b/.github/workflows/ai-coder.yml
@@ -125,13 +125,13 @@ jobs:
 
 
     steps:
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
 
       - name: Download build log
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,79 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Maven
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: "21"
           distribution: temurin
+          cache: maven
 
       - name: Build with Maven
-        run: mvn -B package -DskipTests
+        id: build
+        continue-on-error: true
+        run: |
+          mvn clean package -Dmaven.test.skip=true -B 2>&1 | tee build.log
+          BUILD_EXIT=${PIPESTATUS[0]}
+          echo "build_exit_code=$BUILD_EXIT" >> $GITHUB_OUTPUT
+          exit $BUILD_EXIT
+
+      - name: Compile Check
+        id: compile
+        continue-on-error: true
+        run: |
+          if [ -f build.log ]; then
+            mvn compile -B 2>&1 | tee -a build.log
+          else
+            mvn compile -B 2>&1 | tee build.log
+          fi
+
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "## 🔍 ビルド結果" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | ${{ steps.build.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Compile | ${{ steps.compile.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.build.outcome }}" == "success" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### 成果物" >> $GITHUB_STEP_SUMMARY
+            ls -lh target/*.jar 2>/dev/null | awk '{print "- **" $9 "**: " $5}' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build-log
+          path: build.log
+          retention-days: 7
+
+      - name: Upload build results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build-results
+          path: |
+            target/*.jar
+            !*sources.jar
+            !*javadoc.jar
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Get version
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,36 @@
+# MCRPG Project Configuration
+
+## 🌿 作業ブランチルール
+
+**常に `Local50` ブランチで作業を行います。**
+
+### ブランチ戦略
+
+| ブランチ | 用途 | ルール |
+|---------|------|--------|
+| `Local50` | 作業用 | **すべての開発作業はこのブランチで実施** |
+| `main` | 本番 | マージ完了後の安定版のみ |
+
+### 必須ワークフロー
+
+1. **作業開始時**: `git checkout Local50`
+2. **作業中**: Local50でコミット
+3. **mainマージ時**:
+   ```bash
+   git checkout main
+   git merge Local50 --no-ff
+   git push origin main
+   git checkout Local50  # 戻る
+   ```
+4. **同期**: `git merge main` (Local50でmainを取り込む)
+
+### ⚠️ 禁止事項
+
+- **mainブランチでの直接コミット禁止**
+- **Local50以外のブランチ作成禁止**（特別な理由がある場合を除く）
+
+---
+
 # Claude Code Configuration - Claude Flow V3
 
 ## 🚨 AUTOMATIC SWARM ORCHESTRATION


### PR DESCRIPTION
## 📋 概要

AI-CoderワークフローとReleaseワークフローのビルド設定を統合し、プロジェクトのブランチ戦略を文書化しました。

---

## 🔄 変更内容

### 1. Releaseワークフローの強化 (`.github/workflows/release.yml`)

AI-Coderの厳密なビルド設定をReleaseに適用：

| 項目 | 変更 |
|------|------|
| Mavenキャッシュ | 2重キャッシュ構成（actions/cache + setup-java） |
| ログ保存 | `tee build.log` で完全なビルドログを保存 |
| エラーハンドリング | `continue-on-error` + 終了コード記録 |
| Compile Check | 追加のコンパイル検証ステップ |
| Build Summary | GitHub Step Summary に結果表示 |
| 成果物保存 | artifactとして7日間保存 |

### 2. ブランチ戦略の文書化 (`CLAUDE.md`)

プロジェクト固有のルールをドキュメント先頭に追加：

- **Local50**: 作業用ブランチ（すべての開発作業はここで実施）
- **main**: 本番ブランチ（直接コミット禁止）

---

## ✅ チェックリスト

- [x] コードがプロジェクトのコーディング規約に従っている
- [x] ビルド設定がAI-Coderと統合されている
- [x] ドキュメントが更新されている

---

## 🔗 関連Issue

なし（内部的な改善）

---

## 📌 レビュー観点

- Release.ymlのビルド設定がAI-Coder.ymlと同等の厳密さを持っているか
- ブランチ戦略の文書化が適切か