### PR TITLE
Add unit tests for four Skript conditions (Vibe Kanban)

### DIFF
--- a/src/test/java/com/example/rpgplugin/api/skript/conditions/CondCanUpgradeRPGClassTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/conditions/CondCanUpgradeRPGClassTest.java
@@ -1,0 +1,138 @@
+package com.example.rpgplugin.api.skript.conditions;
+
+import ch.njol.skript.lang.Expression;
+import com.example.rpgplugin.RPGPlugin;
+import com.example.rpgplugin.player.PlayerManager;
+import com.example.rpgplugin.player.RPGPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CondCanUpgradeRPGClass テスト")
+class CondCanUpgradeRPGClassTest {
+
+    @Mock
+    private Expression<Player> playerExpr;
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private RPGPlugin plugin;
+
+    @Mock
+    private PlayerManager playerManager;
+
+    @Mock
+    private RPGPlayer rpgPlayer;
+
+    private CondCanUpgradeRPGClass condition;
+    private UUID playerId;
+
+    @BeforeEach
+    void setUp() {
+        condition = new CondCanUpgradeRPGClass();
+        condition.init(new Expression[]{playerExpr}, 0, null, null);
+        playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+    }
+
+    @Test
+    @DisplayName("check: プレイヤーがnullの場合はfalse")
+    void check_PlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(null);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: プラグイン取得失敗の場合はfalse")
+    void check_PluginNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: RPGPlayer未登録の場合はfalse")
+    void check_RpgPlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: クラスIDがnullの場合はfalse")
+    void check_ClassIdNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.getClassId()).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: クラスIDが空の場合はfalse")
+    void check_ClassIdEmpty_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.getClassId()).thenReturn("");
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: クラスIDが設定済みならtrue")
+    void check_ClassIdPresent_ReturnsTrue() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.getClassId()).thenReturn("warrior");
+
+            assertTrue(condition.check(event));
+        }
+    }
+}

--- a/src/test/java/com/example/rpgplugin/api/skript/conditions/CondHasRPGSkillTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/conditions/CondHasRPGSkillTest.java
@@ -1,0 +1,140 @@
+package com.example.rpgplugin.api.skript.conditions;
+
+import ch.njol.skript.lang.Expression;
+import com.example.rpgplugin.RPGPlugin;
+import com.example.rpgplugin.player.PlayerManager;
+import com.example.rpgplugin.player.RPGPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CondHasRPGSkill テスト")
+class CondHasRPGSkillTest {
+
+    @Mock
+    private Expression<Player> playerExpr;
+
+    @Mock
+    private Expression<String> skillExpr;
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private RPGPlugin plugin;
+
+    @Mock
+    private PlayerManager playerManager;
+
+    @Mock
+    private RPGPlayer rpgPlayer;
+
+    private CondHasRPGSkill condition;
+    private UUID playerId;
+
+    @BeforeEach
+    void setUp() {
+        condition = new CondHasRPGSkill();
+        condition.init(new Expression[]{playerExpr, skillExpr}, 0, null, null);
+        playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+    }
+
+    @Test
+    @DisplayName("check: プレイヤーがnullの場合はfalse")
+    void check_PlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(null);
+        when(skillExpr.getSingle(event)).thenReturn("fireball");
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: スキル名がnullの場合はfalse")
+    void check_SkillNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(skillExpr.getSingle(event)).thenReturn(null);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: プラグイン取得失敗の場合はfalse")
+    void check_PluginNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(skillExpr.getSingle(event)).thenReturn("fireball");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: RPGPlayer未登録の場合はfalse")
+    void check_RpgPlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(skillExpr.getSingle(event)).thenReturn("fireball");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: スキル保持時はtrue")
+    void check_HasSkill_ReturnsTrue() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(skillExpr.getSingle(event)).thenReturn("fireball");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.hasSkill("fireball")).thenReturn(true);
+
+            assertTrue(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: スキル未保持時はfalse")
+    void check_MissingSkill_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(skillExpr.getSingle(event)).thenReturn("fireball");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.hasSkill("fireball")).thenReturn(false);
+
+            assertFalse(condition.check(event));
+        }
+    }
+}

--- a/src/test/java/com/example/rpgplugin/api/skript/conditions/CondIsRPGClassTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/conditions/CondIsRPGClassTest.java
@@ -1,0 +1,140 @@
+package com.example.rpgplugin.api.skript.conditions;
+
+import ch.njol.skript.lang.Expression;
+import com.example.rpgplugin.RPGPlugin;
+import com.example.rpgplugin.player.PlayerManager;
+import com.example.rpgplugin.player.RPGPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CondIsRPGClass テスト")
+class CondIsRPGClassTest {
+
+    @Mock
+    private Expression<Player> playerExpr;
+
+    @Mock
+    private Expression<String> classExpr;
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private RPGPlugin plugin;
+
+    @Mock
+    private PlayerManager playerManager;
+
+    @Mock
+    private RPGPlayer rpgPlayer;
+
+    private CondIsRPGClass condition;
+    private UUID playerId;
+
+    @BeforeEach
+    void setUp() {
+        condition = new CondIsRPGClass();
+        condition.init(new Expression[]{playerExpr, classExpr}, 0, null, null);
+        playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+    }
+
+    @Test
+    @DisplayName("check: プレイヤーがnullの場合はfalse")
+    void check_PlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(null);
+        when(classExpr.getSingle(event)).thenReturn("warrior");
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: クラス名がnullの場合はfalse")
+    void check_ClassNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(classExpr.getSingle(event)).thenReturn(null);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: プラグイン取得失敗の場合はfalse")
+    void check_PluginNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(classExpr.getSingle(event)).thenReturn("warrior");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: RPGPlayer未登録の場合はfalse")
+    void check_RpgPlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(classExpr.getSingle(event)).thenReturn("warrior");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: クラス一致ならtrue (大文字小文字無視)")
+    void check_ClassMatch_ReturnsTrue() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(classExpr.getSingle(event)).thenReturn("warrior");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.getClassId()).thenReturn("Warrior");
+
+            assertTrue(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: クラス不一致ならfalse")
+    void check_ClassMismatch_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(classExpr.getSingle(event)).thenReturn("warrior");
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(rpgPlayer.getClassId()).thenReturn("mage");
+
+            assertFalse(condition.check(event));
+        }
+    }
+}

--- a/src/test/java/com/example/rpgplugin/api/skript/conditions/CondRPGStatAboveTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/conditions/CondRPGStatAboveTest.java
@@ -1,0 +1,152 @@
+package com.example.rpgplugin.api.skript.conditions;
+
+import ch.njol.skript.lang.Expression;
+import com.example.rpgplugin.RPGPlugin;
+import com.example.rpgplugin.player.PlayerManager;
+import com.example.rpgplugin.player.RPGPlayer;
+import com.example.rpgplugin.stats.Stat;
+import com.example.rpgplugin.stats.StatManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CondRPGStatAbove テスト")
+class CondRPGStatAboveTest {
+
+    @Mock
+    private Expression<Player> playerExpr;
+
+    @Mock
+    private Expression<String> statNameExpr;
+
+    @Mock
+    private Expression<Number> valueExpr;
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private RPGPlugin plugin;
+
+    @Mock
+    private PlayerManager playerManager;
+
+    @Mock
+    private RPGPlayer rpgPlayer;
+
+    @Mock
+    private StatManager statManager;
+
+    private CondRPGStatAbove condition;
+    private UUID playerId;
+
+    @BeforeEach
+    void setUp() {
+        condition = new CondRPGStatAbove();
+        condition.init(new Expression[]{playerExpr, statNameExpr, valueExpr}, 0, null, null);
+        playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(rpgPlayer.getStatManager()).thenReturn(statManager);
+    }
+
+    @Test
+    @DisplayName("check: プレイヤーがnullの場合はfalse")
+    void check_PlayerNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(null);
+        when(statNameExpr.getSingle(event)).thenReturn("STR");
+        when(valueExpr.getSingle(event)).thenReturn(10);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: ステータス名が不正ならfalse")
+    void check_InvalidStat_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(statNameExpr.getSingle(event)).thenReturn("UNKNOWN");
+        when(valueExpr.getSingle(event)).thenReturn(10);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: 値がnullの場合はfalse")
+    void check_ValueNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(statNameExpr.getSingle(event)).thenReturn("STR");
+        when(valueExpr.getSingle(event)).thenReturn(null);
+
+        assertFalse(condition.check(event));
+    }
+
+    @Test
+    @DisplayName("check: プラグイン取得失敗の場合はfalse")
+    void check_PluginNull_ReturnsFalse() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(statNameExpr.getSingle(event)).thenReturn("STR");
+        when(valueExpr.getSingle(event)).thenReturn(10);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(null);
+
+            assertFalse(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: ステータスが閾値以上ならtrue")
+    void check_StatAbove_ReturnsTrue() {
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(statNameExpr.getSingle(event)).thenReturn("STR");
+        when(valueExpr.getSingle(event)).thenReturn(10);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(statManager.getFinalStat(Stat.STRENGTH)).thenReturn(15);
+
+            assertTrue(condition.check(event));
+        }
+    }
+
+    @Test
+    @DisplayName("check: ステータス不足ならfalse (パターン2)")
+    void check_StatBelow_ReturnsFalse_WithAltPattern() {
+        CondRPGStatAbove altCondition = new CondRPGStatAbove();
+        altCondition.init(new Expression[]{statNameExpr, playerExpr, valueExpr}, 1, null, null);
+
+        when(playerExpr.getSingle(event)).thenReturn(player);
+        when(statNameExpr.getSingle(event)).thenReturn("DEX");
+        when(valueExpr.getSingle(event)).thenReturn(20);
+
+        try (MockedStatic<RPGPlugin> mockedStatic = mockStatic(RPGPlugin.class)) {
+            mockedStatic.when(RPGPlugin::getInstance).thenReturn(plugin);
+            when(plugin.getPlayerManager()).thenReturn(playerManager);
+            when(playerManager.getRPGPlayer(playerId)).thenReturn(rpgPlayer);
+            when(statManager.getFinalStat(Stat.DEXTERITY)).thenReturn(10);
+
+            assertFalse(altCondition.check(event));
+        }
+    }
+}


### PR DESCRIPTION
## What
- Add four new JUnit test classes for Skript conditions: `CondHasRPGSkill`, `CondCanUpgradeRPGClass`, `CondIsRPGClass`, and `CondRPGStatAbove`.
- Implement 24 tests (6 per condition) covering null inputs, plugin/player lookup failures, and true/false evaluation paths.
- Cover the alternate init pattern for `CondRPGStatAbove` and stat name parsing to `Stat` enums.

## Why
- The task requires test coverage for Skript condition logic to prevent regressions and validate expected behavior across edge cases.

## Implementation Details
- Use Mockito static mocking for `RPGPlugin.getInstance()` to isolate plugin access.
- Mock Skript `Expression` inputs and `Event` to drive condition evaluation deterministically.
- Validate case-insensitive class matching and stat threshold comparisons.

This PR was written using [Vibe Kanban](https://vibekanban.com)