### PR TITLE
Add Skript event tests and Skript bootstrap (Vibe Kanban)

### DIFF
--- a/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillCastTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillCastTest.java
@@ -1,0 +1,138 @@
+package com.example.rpgplugin.api.skript.events;
+
+import ch.njol.skript.lang.Literal;
+import com.example.rpgplugin.skill.Skill;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EvtRPGSkillCast tests")
+class EvtRPGSkillCastTest {
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Skill skill;
+
+    @Mock
+    private Entity target;
+
+    @BeforeAll
+    static void setUpSkript() {
+        SkriptTestBootstrap.ensureInitialized();
+    }
+
+    @Test
+    @DisplayName("init without pattern keeps the default toString")
+    void initWithoutPatternKeepsDefaultToString() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        assertTrue(evt.init(new Literal[0], 0, null));
+        assertEquals("on rpg skill cast", evt.toString(mock(Event.class), false));
+    }
+
+    @Test
+    @DisplayName("init with pattern uses the skill id in toString")
+    void initWithPatternUsesSkillIdInToString() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.toString(any(Event.class), eq(false))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+        assertEquals("on rpg skill cast of fireball", evt.toString(mock(Event.class), false));
+    }
+
+    @Test
+    @DisplayName("check returns true when no skill id is provided")
+    void checkReturnsTrueWhenSkillIdNull() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        assertTrue(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("check returns true when literal returns null")
+    void checkReturnsTrueWhenLiteralReturnsNull() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn(null);
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+        assertTrue(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("check returns true when skill id matches")
+    void checkReturnsTrueWhenSkillIdMatches() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        Event event = new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 3, target);
+        assertTrue(evt.check(event));
+    }
+
+    @Test
+    @DisplayName("check returns false when skill id does not match")
+    void checkReturnsFalseWhenSkillIdDoesNotMatch() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("ice");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        Event event = new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 3, target);
+        assertFalse(evt.check(event));
+    }
+
+    @Test
+    @DisplayName("check returns false for non skill cast events")
+    void checkReturnsFalseForNonSkillCastEvent() {
+        EvtRPGSkillCast evt = new EvtRPGSkillCast();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        assertFalse(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("default damage is zero in the 5-arg constructor")
+    void defaultDamageIsZeroInConstructor() {
+        EvtRPGSkillCast.RPGSkillCastEvent event =
+                new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 2, target);
+        assertEquals(0.0, event.getDamage(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("event getters return provided values")
+    void eventGettersReturnProvidedValues() {
+        EvtRPGSkillCast.RPGSkillCastEvent event =
+                new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 4, target, 12.5);
+
+        assertSame(player, event.getPlayer());
+        assertEquals("fireball", event.getSkillId());
+        assertSame(skill, event.getSkill());
+        assertEquals(4, event.getSkillLevel());
+        assertSame(target, event.getTarget());
+        assertEquals(12.5, event.getDamage(), 0.0001);
+    }
+}

--- a/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillCastTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillCastTest.java
@@ -115,11 +115,27 @@ class EvtRPGSkillCastTest {
     }
 
     @Test
-    @DisplayName("default damage is zero in the 5-arg constructor")
-    void defaultDamageIsZeroInConstructor() {
+    @DisplayName("default damage is zero in the 4-arg constructor")
+    void defaultDamageIsZeroInFourArgConstructor() {
         EvtRPGSkillCast.RPGSkillCastEvent event =
                 new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 2, target);
         assertEquals(0.0, event.getDamage(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("5-arg constructor with explicit zero damage")
+    void fiveArgConstructorWithZeroDamage() {
+        EvtRPGSkillCast.RPGSkillCastEvent event =
+                new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 2, target, 0.0);
+        assertEquals(0.0, event.getDamage(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("5-arg constructor with positive damage")
+    void fiveArgConstructorWithPositiveDamage() {
+        EvtRPGSkillCast.RPGSkillCastEvent event =
+                new EvtRPGSkillCast.RPGSkillCastEvent(player, "fireball", skill, 2, target, 15.5);
+        assertEquals(15.5, event.getDamage(), 0.0001);
     }
 
     @Test

--- a/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillDamageTest.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/events/EvtRPGSkillDamageTest.java
@@ -1,0 +1,141 @@
+package com.example.rpgplugin.api.skript.events;
+
+import ch.njol.skript.lang.Literal;
+import com.example.rpgplugin.skill.Skill;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EvtRPGSkillDamage tests")
+class EvtRPGSkillDamageTest {
+
+    @Mock
+    private Player player;
+
+    @Mock
+    private Skill skill;
+
+    @Mock
+    private Entity target;
+
+    @BeforeAll
+    static void setUpSkript() {
+        SkriptTestBootstrap.ensureInitialized();
+    }
+
+    @Test
+    @DisplayName("init without pattern keeps the default toString")
+    void initWithoutPatternKeepsDefaultToString() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        assertTrue(evt.init(new Literal[0], 0, null));
+        assertEquals("on rpg skill damage", evt.toString(mock(Event.class), false));
+    }
+
+    @Test
+    @DisplayName("init with pattern uses the skill id in toString")
+    void initWithPatternUsesSkillIdInToString() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.toString(any(Event.class), eq(false))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+        assertEquals("on rpg skill damage of fireball", evt.toString(mock(Event.class), false));
+    }
+
+    @Test
+    @DisplayName("check returns true when no skill id is provided")
+    void checkReturnsTrueWhenSkillIdNull() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        assertTrue(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("check returns true when literal returns null")
+    void checkReturnsTrueWhenLiteralReturnsNull() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn(null);
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+        assertTrue(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("check returns true when skill id matches")
+    void checkReturnsTrueWhenSkillIdMatches() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        Event event = new EvtRPGSkillDamage.RPGSkillDamageEvent(player, "fireball", skill, 3, target, 7.5);
+        assertTrue(evt.check(event));
+    }
+
+    @Test
+    @DisplayName("check returns false when skill id does not match")
+    void checkReturnsFalseWhenSkillIdDoesNotMatch() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("ice");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        Event event = new EvtRPGSkillDamage.RPGSkillDamageEvent(player, "fireball", skill, 3, target, 7.5);
+        assertFalse(evt.check(event));
+    }
+
+    @Test
+    @DisplayName("check returns false for non skill damage events")
+    void checkReturnsFalseForNonSkillDamageEvent() {
+        EvtRPGSkillDamage evt = new EvtRPGSkillDamage();
+        @SuppressWarnings("unchecked")
+        Literal<String> literal = mock(Literal.class);
+        when(literal.getSingle(any(Event.class))).thenReturn("fireball");
+        assertTrue(evt.init(new Literal[]{literal}, 1, null));
+
+        assertFalse(evt.check(mock(Event.class)));
+    }
+
+    @Test
+    @DisplayName("event getters return provided values")
+    void eventGettersReturnProvidedValues() {
+        EvtRPGSkillDamage.RPGSkillDamageEvent event =
+                new EvtRPGSkillDamage.RPGSkillDamageEvent(player, "fireball", skill, 4, target, 12.5);
+
+        assertSame(player, event.getPlayer());
+        assertEquals("fireball", event.getSkillId());
+        assertSame(skill, event.getSkill());
+        assertEquals(4, event.getSkillLevel());
+        assertSame(target, event.getTarget());
+        assertEquals(12.5, event.getDamage(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("handlers are shared across instances")
+    void handlersAreSharedAcrossInstances() {
+        EvtRPGSkillDamage.RPGSkillDamageEvent first =
+                new EvtRPGSkillDamage.RPGSkillDamageEvent(player, "fireball", skill, 1, target, 1.0);
+        EvtRPGSkillDamage.RPGSkillDamageEvent second =
+                new EvtRPGSkillDamage.RPGSkillDamageEvent(player, "fireball", skill, 1, target, 1.0);
+
+        assertSame(first.getHandlers(), second.getHandlers());
+    }
+}

--- a/src/test/java/com/example/rpgplugin/api/skript/events/SkriptTestBootstrap.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/events/SkriptTestBootstrap.java
@@ -3,68 +3,123 @@ package com.example.rpgplugin.api.skript.events;
 import ch.njol.skript.Skript;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
+/**
+ * Skriptテスト用ブートストラップクラス。
+ *
+ * <p>このクラスはテスト環境でのSkriptの初期化を担当します。
+ * 初期化オンデマンドホルダーイディオムを使用することで、スレッドセーフかつ遅延初期化を実現しています。</p>
+ *
+ * @see <a href="https://www.javaalmanac.com/effective-java/item-83-use-lazy-initialization-judiciously">Effective Java Item 83</a>
+ */
 final class SkriptTestBootstrap {
 
-    private static boolean initialized;
-
     private SkriptTestBootstrap() {
+        // ユーティリティクラスのためインスタンス化を禁止
     }
 
+    /**
+     * Skriptの初期化を保証します。
+     *
+     * <p>このメソッドはHolderクラスを参照することで、
+     * クラスロード時の静的初期化ブロックの実行をトリガーします。
+     * Java言語仕様により静的初期化はスレッドセーフであることが保証されています。</p>
+     */
     static void ensureInitialized() {
-        if (initialized) {
-            return;
-        }
-        synchronized (SkriptTestBootstrap.class) {
-            if (initialized) {
-                return;
-            }
+        // Holderクラスを参照することで静的初期化をトリガー
+        Holder.initialize();
+    }
+
+    /**
+     * 初期化オンデマンドホルダーイディオム。
+     *
+     * <p>静的初期化ブロックはHolderクラスが最初に参照されたときに1回だけ実行され、
+     * Java言語仕様によりスレッドセーフであることが保証されています。</p>
+     */
+    private static final class Holder {
+
+        static {
             try {
-                Field instanceField = Skript.class.getDeclaredField("instance");
-                instanceField.setAccessible(true);
-                Object instance = instanceField.get(null);
-                if (instance == null) {
-                    instance = allocateInstance(Skript.class);
-                    instanceField.set(null, instance);
-                }
-                setJavaPluginEnabled(instance, true);
-
-                Field skriptField = Skript.class.getDeclaredField("skript");
-                skriptField.setAccessible(true);
-                if (skriptField.get(null) == null) {
-                    skriptField.set(null, org.skriptlang.skript.Skript.of(SkriptTestBootstrap.class, "test"));
-                }
-
-                Field unmodifiableField = Skript.class.getDeclaredField("unmodifiableSkript");
-                unmodifiableField.setAccessible(true);
-                if (unmodifiableField.get(null) == null) {
-                    org.skriptlang.skript.Skript skriptInstance =
-                            (org.skriptlang.skript.Skript) skriptField.get(null);
-                    unmodifiableField.set(null, skriptInstance.unmodifiableView());
-                }
-
-                Field acceptField = Skript.class.getDeclaredField("acceptRegistrations");
-                acceptField.setAccessible(true);
-                acceptField.setBoolean(null, true);
-
-                initialized = true;
+                initializeSkript();
             } catch (ReflectiveOperationException e) {
-                throw new IllegalStateException("Failed to initialize Skript for tests", e);
+                throw new ExceptionInInitializerError("Failed to initialize Skript for tests: " + e.getMessage());
             }
         }
-    }
 
-    private static Object allocateInstance(Class<?> type) throws ReflectiveOperationException {
-        Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-        unsafeField.setAccessible(true);
-        sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
-        return unsafe.allocateInstance(type);
-    }
+        /**
+         * Skriptの初期化処理を実行します。
+         */
+        static void initialize() {
+            // 静的初期化ブロックの実行を保証するダミーメソッド
+        }
 
-    private static void setJavaPluginEnabled(Object instance, boolean enabled) throws ReflectiveOperationException {
-        Field enabledField = JavaPlugin.class.getDeclaredField("isEnabled");
-        enabledField.setAccessible(true);
-        enabledField.setBoolean(instance, enabled);
+        /**
+         * Skriptの初期化を実行します。
+         */
+        private static void initializeSkript() throws ReflectiveOperationException {
+            // Skriptインスタンスの初期化
+            Field instanceField = Skript.class.getDeclaredField("instance");
+            instanceField.setAccessible(true);
+            Object instance = instanceField.get(null);
+            if (instance == null) {
+                instance = allocateInstance(Skript.class);
+                instanceField.set(null, instance);
+            }
+            setJavaPluginEnabled(instance, true);
+
+            // Skript APIの初期化
+            Field skriptField = Skript.class.getDeclaredField("skript");
+            skriptField.setAccessible(true);
+            if (skriptField.get(null) == null) {
+                skriptField.set(null, org.skriptlang.skript.Skript.of(SkriptTestBootstrap.class, "test"));
+            }
+
+            // 不変Skriptインスタンスの初期化
+            Field unmodifiableField = Skript.class.getDeclaredField("unmodifiableSkript");
+            unmodifiableField.setAccessible(true);
+            if (unmodifiableField.get(null) == null) {
+                org.skriptlang.skript.Skript skriptInstance =
+                        (org.skriptlang.skript.Skript) skriptField.get(null);
+                unmodifiableField.set(null, skriptInstance.unmodifiableView());
+            }
+
+            // 登録受け入れフラグの設定
+            Field acceptField = Skript.class.getDeclaredField("acceptRegistrations");
+            acceptField.setAccessible(true);
+            acceptField.setBoolean(null, true);
+        }
+
+        /**
+         * リフレクションを使用してクラスのインスタンスを生成します。
+         *
+         * <p>このメソッドはsun.misc.Unsafeの代わりに標準Reflection APIを使用します。
+         * JDK 9以降のモジュールシステムと互換性があります。</p>
+         *
+         * @param type インスタンスを生成するクラス
+         * @return 生成されたインスタンス
+         * @throws ReflectiveOperationException インスタンス生成に失敗した場合
+         */
+        private static Object allocateInstance(Class<?> type) throws ReflectiveOperationException {
+            Constructor<?> ctor = type.getDeclaredConstructor();
+            if (!ctor.canAccess(null)) {
+                ctor.setAccessible(true);
+            }
+            return ctor.newInstance();
+        }
+
+        /**
+         * JavaPluginの有効状態を設定します。
+         *
+         * @param instance Skriptインスタンス
+         * @param enabled 有効にする場合はtrue
+         * @throws ReflectiveOperationException フィールドアクセスに失敗した場合
+         */
+        private static void setJavaPluginEnabled(Object instance, boolean enabled) throws ReflectiveOperationException {
+            Field enabledField = JavaPlugin.class.getDeclaredField("isEnabled");
+            enabledField.setAccessible(true);
+            enabledField.setBoolean(instance, enabled);
+        }
     }
 }

--- a/src/test/java/com/example/rpgplugin/api/skript/events/SkriptTestBootstrap.java
+++ b/src/test/java/com/example/rpgplugin/api/skript/events/SkriptTestBootstrap.java
@@ -1,0 +1,70 @@
+package com.example.rpgplugin.api.skript.events;
+
+import ch.njol.skript.Skript;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.Field;
+
+final class SkriptTestBootstrap {
+
+    private static boolean initialized;
+
+    private SkriptTestBootstrap() {
+    }
+
+    static void ensureInitialized() {
+        if (initialized) {
+            return;
+        }
+        synchronized (SkriptTestBootstrap.class) {
+            if (initialized) {
+                return;
+            }
+            try {
+                Field instanceField = Skript.class.getDeclaredField("instance");
+                instanceField.setAccessible(true);
+                Object instance = instanceField.get(null);
+                if (instance == null) {
+                    instance = allocateInstance(Skript.class);
+                    instanceField.set(null, instance);
+                }
+                setJavaPluginEnabled(instance, true);
+
+                Field skriptField = Skript.class.getDeclaredField("skript");
+                skriptField.setAccessible(true);
+                if (skriptField.get(null) == null) {
+                    skriptField.set(null, org.skriptlang.skript.Skript.of(SkriptTestBootstrap.class, "test"));
+                }
+
+                Field unmodifiableField = Skript.class.getDeclaredField("unmodifiableSkript");
+                unmodifiableField.setAccessible(true);
+                if (unmodifiableField.get(null) == null) {
+                    org.skriptlang.skript.Skript skriptInstance =
+                            (org.skriptlang.skript.Skript) skriptField.get(null);
+                    unmodifiableField.set(null, skriptInstance.unmodifiableView());
+                }
+
+                Field acceptField = Skript.class.getDeclaredField("acceptRegistrations");
+                acceptField.setAccessible(true);
+                acceptField.setBoolean(null, true);
+
+                initialized = true;
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Failed to initialize Skript for tests", e);
+            }
+        }
+    }
+
+    private static Object allocateInstance(Class<?> type) throws ReflectiveOperationException {
+        Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
+        return unsafe.allocateInstance(type);
+    }
+
+    private static void setJavaPluginEnabled(Object instance, boolean enabled) throws ReflectiveOperationException {
+        Field enabledField = JavaPlugin.class.getDeclaredField("isEnabled");
+        enabledField.setAccessible(true);
+        enabledField.setBoolean(instance, enabled);
+    }
+}


### PR DESCRIPTION
## What
- Added unit tests for `EvtRPGSkillCast` and `EvtRPGSkillDamage` (9 tests each).
- Introduced a `SkriptTestBootstrap` helper to initialize Skript static state for tests.

## Why
- The task requires validating two Skript event classes with 18 total tests.
- Skript performs static registration at class-load time; without a minimal Skript instance, tests would fail during initialization.

## Implementation details
- `SkriptTestBootstrap` uses reflection/Unsafe to set Skript's internal instance and enable registrations in a test-safe way.
- Tests cover init patterns, `check` branch behavior, `toString` formatting, and event getter/default damage paths.

This PR was written using [Vibe Kanban](https://vibekanban.com)
